### PR TITLE
Implements model save options, issue #110

### DIFF
--- a/djadmin2/templates/admin2/bootstrap/model_add_form.html
+++ b/djadmin2/templates/admin2/bootstrap/model_add_form.html
@@ -5,7 +5,9 @@
 <form method="post">
     {% csrf_token %}
     {{ form.as_p }}
-    <input type="submit"/>
+    <button class="btn btn-small" type="submit" name="_addanother">Save and add another</button>
+    <button class="btn btn-small" type="submit" name="_continue">Save and continue editing</button>
+    <button class="btn btn-small btn-success" type="submit" name="_save">Save</button>
 </form>
 
 {% endblock content %}

--- a/djadmin2/views.py
+++ b/djadmin2/views.py
@@ -121,12 +121,23 @@ class ModelEditFormView(AdminModel2Mixin, generic.UpdateView):
 
 class ModelAddFormView(AdminModel2Mixin, generic.CreateView):
     form_class = None
-    success_url = "../"
     default_template_name = "model_add_form.html"
     permission_type = 'add'
 
     def get_success_url(self):
-        view_name = 'admin2:{}_{}_detail'.format(self.app_label, self.model_name)
+        if '_continue' in self.request.POST:
+            view_name = 'admin2:{}_{}_update'.format(self.app_label,
+                                                     self.model_name)
+            return reverse(view_name, kwargs={'pk': self.object.pk})
+
+        if '_addanother' in self.request.POST:
+            view_name = 'admin2:{}_{}_create'.format(self.app_label,
+                                                     self.model_name)
+            return reverse(view_name)
+
+        # default to detail view
+        view_name = 'admin2:{}_{}_detail'.format(self.app_label,
+                                                 self.model_name)
         return reverse(view_name, kwargs={'pk': self.object.pk})
 
 

--- a/example/blog/tests/test_views.py
+++ b/example/blog/tests/test_views.py
@@ -54,6 +54,34 @@ class PostCreateViewTest(BaseIntegrationTest):
         self.assertRedirects(response, reverse("admin2:blog_post_detail",
                                                args=(post.pk, )))
 
+    def test_save_and_add_another_redirects_to_create(self):
+        """
+        Tests that choosing 'Save and add another' from the model create 
+        page redirects the user to the model create page.
+        """
+        post_data = {"title": "a_post_title",
+                     "body": "a_post_body",
+                     "_addanother": ""}
+        self.client.login(username='admin', password='password')
+        response = self.client.post(reverse("admin2:blog_post_create"),
+                                    post_data)
+        post = Post.objects.get(title='a_post_title')
+        self.assertRedirects(response, reverse("admin2:blog_post_create"))
+
+    def test_save_and_continue_editing_redirects_to_update(self):
+        """
+        Tests that choosing "Save and continue editing" redirects 
+        the user to the model update form.
+        """
+        post_data = {"title": "Unique",
+                     "body": "a_post_body",
+                     "_continue": ""}
+        response = self.client.post(reverse("admin2:blog_post_create"),
+                                    post_data)
+        post = Post.objects.get(title="Unique")
+        self.assertRedirects(response, reverse("admin2:blog_post_update",
+                                               args=(post.pk, )))
+
 
 class PostDeleteViewTest(BaseIntegrationTest):
     def test_view_ok(self):


### PR DESCRIPTION
This PR implements the 'Save', 'Save and continue editing', and 'Save and add another' options on the model create page. Tests for the appropriate redirects are included.

Note that the original admin2 behaviour of redirecting 'Save' to the model 'detail' page is unchanged, even though this differs from the contrib.admin behaviour of redirecting to the model index page. It's unclear if this is a feature or a bug, so I left it alone.
![save_options](https://f.cloud.github.com/assets/238952/532364/2bb2680c-c144-11e2-9d60-9a32cf62f548.png)
