### PR TITLE
Add page title to model create page

### DIFF
--- a/djadmin2/templates/admin2/bootstrap/model_add_form.html
+++ b/djadmin2/templates/admin2/bootstrap/model_add_form.html
@@ -2,6 +2,7 @@
 
 {% block content %}
 
+<h3>Add {{ model|capfirst }}</h3>
 <form method="post">
     {% csrf_token %}
     {{ form.as_p }}

--- a/djadmin2/views.py
+++ b/djadmin2/views.py
@@ -125,6 +125,11 @@ class ModelAddFormView(AdminModel2Mixin, generic.CreateView):
     default_template_name = "model_add_form.html"
     permission_type = 'add'
 
+    def get_context_data(self, **kwargs):
+        context = super(ModelAddFormView, self).get_context_data(**kwargs)
+        context['model'] = self.get_model()._meta.verbose_name
+        return context
+
     def get_success_url(self):
         view_name = 'admin2:{}_{}_detail'.format(self.app_label, self.model_name)
         return reverse(view_name, kwargs={'pk': self.object.pk})


### PR DESCRIPTION
Model create page is missing a page title.

![missing_page_title](https://f.cloud.github.com/assets/238952/535948/7fde6368-c14e-11e2-98cb-6a1e23b4538d.png)

Added:
![with_page_title](https://f.cloud.github.com/assets/238952/535952/a4a122ee-c14e-11e2-8cf2-ddf96f720185.png)

This PR adds the model name to the template context.
