### PR TITLE
Add 'title' and 'page_title' template blocks.

### DIFF
--- a/djadmin2/templates/admin2/bootstrap/base.html
+++ b/djadmin2/templates/admin2/bootstrap/base.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8">
 
-        <title>django-admin2</title>
+        <title>{% block title %}Site administration{% endblock %} | django-admin2</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <!-- Bootstrap -->
         <link href="{{ STATIC_URL }}themes/bootstrap/css/bootstrap.min.css" rel="stylesheet" media="screen">
@@ -46,6 +46,11 @@
         </div>
 
         <div class="container-fluid">
+            <div class="row">
+                <div class="span10">
+                    <h3>{% block page_title %}Site administration{% endblock %}</h3>
+                </div>
+            </div>
             {% block content %}{% endblock %}
         </div>
 

--- a/djadmin2/templates/admin2/bootstrap/index.html
+++ b/djadmin2/templates/admin2/bootstrap/index.html
@@ -2,7 +2,6 @@
 {% load admin2_urls %}
 
 {% block content %}
-<h3>Site administration</h3>
 
 <div class="row">
     <div class="span7">

--- a/djadmin2/templates/admin2/bootstrap/model_add_form.html
+++ b/djadmin2/templates/admin2/bootstrap/model_add_form.html
@@ -1,8 +1,11 @@
 {% extends "admin2/bootstrap/base.html" %}
 
+{% block title %}Add {{ model }}{% endblock %}
+
+{% block page_title %}Add {{ model }}{% endblock %}
+
 {% block content %}
 
-<h3>Add {{ model|capfirst }}</h3>
 <form method="post">
     {% csrf_token %}
     {{ form.as_p }}

--- a/djadmin2/templates/admin2/bootstrap/model_confirm_delete.html
+++ b/djadmin2/templates/admin2/bootstrap/model_confirm_delete.html
@@ -1,5 +1,9 @@
 {% extends "admin2/bootstrap/base.html" %}
 
+{% block title %}Delete {{ model }}{% endblock %}
+
+{% block page_title %}Delete {{ model }}{% endblock %}
+
 {% block content %}
 
 <form method="post">

--- a/djadmin2/templates/admin2/bootstrap/model_detail.html
+++ b/djadmin2/templates/admin2/bootstrap/model_detail.html
@@ -1,5 +1,9 @@
 {% extends "admin2/bootstrap/base.html" %}
 
+{% block title %}{{ object }}{% endblock %}
+
+{% block page_title %}{{ object }}{% endblock %}
+
 {% block content %}
 
 {{ object }}

--- a/djadmin2/templates/admin2/bootstrap/model_edit_form.html
+++ b/djadmin2/templates/admin2/bootstrap/model_edit_form.html
@@ -1,13 +1,10 @@
 {% extends "admin2/bootstrap/base.html" %}
 
+{% block title %}Change {{ model }}{% endblock %}
+
+{% block page_title %}Change {{ model }}{% endblock %}
+
 {% block content %}
-
-<div class="row">
-    <div class="span10">
-        <h3>Change {{ model }}</h3>
-    </div>
-</div>
-
 
 <div class="row">
     <div class="span12">

--- a/djadmin2/templates/admin2/bootstrap/model_list.html
+++ b/djadmin2/templates/admin2/bootstrap/model_list.html
@@ -1,13 +1,11 @@
 {% extends "admin2/bootstrap/base.html" %}
 {% load admin2_urls %}
 
-{% block content %}
-<div class="row">
-    <div class="span10">
-        <h3>Select {{ model }} to change</h3>
-    </div>
-</div>
+{% block title %}Select {{ model }} to change{% endblock %}
 
+{% block page_title %}Select {{ model }} to change{% endblock %}
+
+{% block content %}
 
 <div class="row">
     <div class="span12">


### PR DESCRIPTION
Makes template page title styling consistent across all templates.
Also introduces a 'title' template block for the browser tab title.
