### PR TITLE
Remove unused Admin2Form class.

### DIFF
--- a/djadmin2/forms.py
+++ b/djadmin2/forms.py
@@ -1,7 +1,0 @@
-from django import forms
-
-
-class Admin2Form(forms.ModelForm):
-
-    pass
-


### PR DESCRIPTION
I removed forms.py because it contained nothing but an unused Admin2Form class, which was originally a planned stub but has no foreseeable future.
