### PR TITLE
Fixes message display after action handling.

### DIFF
--- a/djadmin2/actions.py
+++ b/djadmin2/actions.py
@@ -33,13 +33,15 @@ def delete_selected(request, queryset):
         objects_name = opts.verbose_name
     else:
         objects_name = opts.verbose_name_plural
+    objects_name = unicode(objects_name)
 
     if request.POST.get('confirmed'):
         # The user has confirmed that they want to delete the objects.
         if has_permission:
+            num_objects_deleted = len(queryset)
             queryset.delete()
             message = "Successfully deleted %d %s" % \
-                    (len(queryset), objects_name)
+                    (num_objects_deleted, objects_name)
             messages.add_message(request, messages.INFO, message)
             return None
         else:

--- a/example/blog/tests/test_views.py
+++ b/example/blog/tests/test_views.py
@@ -130,3 +130,33 @@ class PostDeleteViewTest(BaseIntegrationTest):
                                             args=(post.pk, )))
         self.assertRedirects(response, reverse("admin2:blog_post_index"))
         self.assertFalse(Post.objects.filter(pk=post.pk).exists())
+
+
+class PostDeleteActionTest(BaseIntegrationTest):
+    """
+    Tests the behaviour of the 'Delete selected items' action.
+    """
+    def test_confirmation_page(self):
+        p1 = Post.objects.create(title="A Post Title", body="body")
+        p2 = Post.objects.create(title="A Post Title", body="body")
+        post_data = {
+            'action': 'delete_selected',
+            'selected_model_id': [p1.id, p2.id]
+        }
+        response = self.client.post(reverse("admin2:blog_post_index"),
+                                    post_data)
+        self.assertContains(response, p1.title)
+        self.assertContains(response, p2.title)
+
+    def test_results_page(self):
+        p1 = Post.objects.create(title="A Post Title", body="body")
+        p2 = Post.objects.create(title="A Post Title", body="body")
+        post_data = {
+            'action': 'delete_selected',
+            'selected_model_id': [p1.id, p2.id],
+            'confirmed': 'yes'
+        }
+        response = self.client.post(reverse("admin2:blog_post_index"),
+                                    post_data, follow=True)
+        self.assertContains(response, "Successfully deleted 2 posts")
+


### PR DESCRIPTION
Calls unicode to force encoding of object name to a localized
unicode string. Also fixes deleted object count by saving
len(queryset) to a local var before calling queryset.delete(), as
the len after queryset.delete() is always zero.

Includes tests for the delete action confirmation and results pages. Fixes issue #137
