### PR TITLE
Use PK instead of ID in the model list view and template

### DIFF
--- a/djadmin2/templates/admin2/bootstrap/delete_selected_confirmation.html
+++ b/djadmin2/templates/admin2/bootstrap/delete_selected_confirmation.html
@@ -15,7 +15,7 @@
     <input type="hidden" name="confirmed" value="yes" />
     <input type="hidden" name="action" value="delete_selected" />
     {% for item in queryset %}
-    <input type="hidden" name="selected_model_id" value="{{ item.id }}" />
+    <input type="hidden" name="selected_model_pk" value="{{ item.pk }}" />
     {% endfor %}
     <input type="submit"/>
 </form>

--- a/djadmin2/templates/admin2/bootstrap/model_list.html
+++ b/djadmin2/templates/admin2/bootstrap/model_list.html
@@ -38,7 +38,7 @@
                 <tbody>
                     {% for obj in object_list %}
                     <tr>
-                        <td><input type="checkbox" class="model-select" name="selected_model_id" value="{{obj.id}}"></td>
+                        <td><input type="checkbox" class="model-select" name="selected_model_pk" value="{{ obj.pk }}"></td>
                         <td>
                             {{ obj }} <a href="{% url view|admin2_urlname:'detail' pk=obj.pk %}">detail</a>
                             {# if has_edit_permission #}

--- a/djadmin2/views.py
+++ b/djadmin2/views.py
@@ -29,8 +29,8 @@ class ModelListView(Admin2Mixin, generic.ListView):
         # This is where we handle actions
         action_name = request.POST['action']
         action_func = self.get_actions()[action_name]['func']
-        selected_model_ids = request.POST.getlist('selected_model_id')
-        queryset = self.model.objects.filter(pk__in=selected_model_ids)
+        selected_model_pks = request.POST.getlist('selected_model_pk')
+        queryset = self.model.objects.filter(pk__in=selected_model_pks)
         response = action_func(request, queryset)
         if response is None:
             return HttpResponseRedirect(self.get_success_url())

--- a/example/blog/tests/test_views.py
+++ b/example/blog/tests/test_views.py
@@ -36,13 +36,13 @@ class PostListTest(BaseIntegrationTest):
 
     def test_delete_selected_post(self):
         post = Post.objects.create(title="a_post_title", body="body")
-        params = {'action': 'delete_selected', 'selected_model_id': str(post.id)}
+        params = {'action': 'delete_selected', 'selected_model_pk': str(post.pk)}
         response = self.client.post(reverse("admin2:blog_post_index"), params)
         self.assertInHTML('<p>Are you sure you want to delete the selected post?</p>', response.content)
 
     def test_delete_selected_post_confirmation(self):
         post = Post.objects.create(title="a_post_title", body="body")
-        params = {'action': 'delete_selected', 'selected_model_id': str(post.id), 'confirmed': 'yes'}
+        params = {'action': 'delete_selected', 'selected_model_pk': str(post.pk), 'confirmed': 'yes'}
         response = self.client.post(reverse("admin2:blog_post_index"), params)
         self.assertRedirects(response, reverse("admin2:blog_post_index"))
 
@@ -141,7 +141,7 @@ class PostDeleteActionTest(BaseIntegrationTest):
         p2 = Post.objects.create(title="A Post Title", body="body")
         post_data = {
             'action': 'delete_selected',
-            'selected_model_id': [p1.id, p2.id]
+            'selected_model_pk': [p1.pk, p2.pk]
         }
         response = self.client.post(reverse("admin2:blog_post_index"),
                                     post_data)
@@ -153,7 +153,7 @@ class PostDeleteActionTest(BaseIntegrationTest):
         p2 = Post.objects.create(title="A Post Title", body="body")
         post_data = {
             'action': 'delete_selected',
-            'selected_model_id': [p1.id, p2.id],
+            'selected_model_pk': [p1.pk, p2.pk],
             'confirmed': 'yes'
         }
         response = self.client.post(reverse("admin2:blog_post_index"),


### PR DESCRIPTION
Deleting instances is broken if the model doesn't have an ID field. Switching to use PK instead fixes this (and potentially other issues).

Tests have been updated and the same number of misses are reported for me as before my changes. :-)
