### PR TITLE
Fix for Issue #178

### DIFF
--- a/djadmin2/actions.py
+++ b/djadmin2/actions.py
@@ -35,7 +35,12 @@ class BaseListAction(object):
         self.permission_name = '%s.delete.%s' \
                 % (self.options.app_label, self.options.object_name.lower())
         self.has_permission = request.user.has_perm(self.permission_name)
-        if queryset.count() == 1:
+
+        self.item_count = queryset.count()
+
+        if self.item_count == 0:
+            objects_name = self.options.verbose_name
+        elif self.item_count == 1:
             objects_name = self.options.verbose_name
         else:
             objects_name = self.options.verbose_name_plural
@@ -51,7 +56,12 @@ class BaseListAction(object):
         return NotImplemented
 
     def __call__(self):
-        return self.get_response()
+        if self.item_count > 0:
+            return self.get_response()
+        else:
+            message = _("Items must be selected in order to perform actions on them. No items have been changed.")
+            messages.add_message(self.request, messages.INFO, message)
+            return None
 
 
 class DeleteSelectedAction(BaseListAction):

--- a/example/blog/tests/test_views.py
+++ b/example/blog/tests/test_views.py
@@ -46,6 +46,12 @@ class PostListTest(BaseIntegrationTest):
         response = self.client.post(reverse("admin2:blog_post_index"), params)
         self.assertRedirects(response, reverse("admin2:blog_post_index"))
 
+    def test_delete_selected_post_none_selected(self):
+        post = Post.objects.create(title="a_post_title", body="body")
+        params = {'action': 'DeleteSelectedAction'}
+        response = self.client.post(reverse("admin2:blog_post_index"), params)
+        self.assertInHTML("Items must be selected in order to perform actions on them. No items have been changed.")
+
 
 class PostDetailViewTest(BaseIntegrationTest):
     def test_view_ok(self):


### PR DESCRIPTION
If an action is selected and no objects are selected the message "Items must be selected in order to perform actions on them. No items have been changed." is displayed instead of the user being sent to Action confirmation screen.

https://github.com/twoscoops/django-admin2/issues/178
