### PR TITLE
Add basic Vagrant provisioning script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ logfile
 
 # vim swap files
 *.sw[o-z]
+
+# Vagrant state files
+.vagrant

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,19 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "precise32"
+
+  # The url from where the 'config.vm.box' box will be fetched if it
+  # doesn't already exist on the user's system.
+  config.vm.box_url = "http://files.vagrantup.com/precise32.box"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  config.vm.network :private_network, ip: "10.0.0.10"
+
+  config.vm.provision :shell, :path => "provision.sh", :args => "djadmin2"
+
+  config.vm.synced_folder "..", "/home/vagrant/djadmin2"
+
+end

--- a/vagrant/bashrc
+++ b/vagrant/bashrc
@@ -1,0 +1,103 @@
+# ~/.bashrc: executed by bash(1) for non-login shells.
+# see /usr/share/doc/bash/examples/startup-files (in the package bash-doc)
+# for examples
+
+# If not running interactively, don't do anything
+[ -z "$PS1" ] && return
+
+# don't put duplicate lines in the history. See bash(1) for more options
+# ... or force ignoredups and ignorespace
+HISTCONTROL=ignoredups:ignorespace
+
+# append to the history file, don't overwrite it
+shopt -s histappend
+
+# for setting history length see HISTSIZE and HISTFILESIZE in bash(1)
+HISTSIZE=1000
+HISTFILESIZE=2000
+
+# check the window size after each command and, if necessary,
+# update the values of LINES and COLUMNS.
+shopt -s checkwinsize
+
+# make less more friendly for non-text input files, see lesspipe(1)
+[ -x /usr/bin/lesspipe ] && eval "$(SHELL=/bin/sh lesspipe)"
+
+# set variable identifying the chroot you work in (used in the prompt below)
+if [ -z "$debian_chroot" ] && [ -r /etc/debian_chroot ]; then
+    debian_chroot=$(cat /etc/debian_chroot)
+fi
+
+# set a fancy prompt (non-color, unless we know we "want" color)
+case "$TERM" in
+    xterm-color) color_prompt=yes;;
+esac
+
+# uncomment for a colored prompt, if the terminal has the capability; turned
+# off by default to not distract the user: the focus in a terminal window
+# should be on the output of commands, not on the prompt
+#force_color_prompt=yes
+
+if [ -n "$force_color_prompt" ]; then
+    if [ -x /usr/bin/tput ] && tput setaf 1 >&/dev/null; then
+        # We have color support; assume it's compliant with Ecma-48
+        # (ISO/IEC-6429). (Lack of such support is extremely rare, and such
+        # a case would tend to support setf rather than setaf.)
+        color_prompt=yes
+    else
+        color_prompt=
+    fi
+fi
+
+if [ "$color_prompt" = yes ]; then
+    PS1='${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
+else
+    PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
+fi
+unset color_prompt force_color_prompt
+
+# If this is an xterm set the title to user@host:dir
+case "$TERM" in
+xterm*|rxvt*)
+    PS1="\[\e]0;${debian_chroot:+($debian_chroot)}\u@\h: \w\a\]$PS1"
+    ;;
+*)
+    ;;
+esac
+
+# enable color support of ls and also add handy aliases
+if [ -x /usr/bin/dircolors ]; then
+    test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
+    alias ls='ls --color=auto'
+    #alias dir='dir --color=auto'
+    #alias vdir='vdir --color=auto'
+
+    alias grep='grep --color=auto'
+    alias fgrep='fgrep --color=auto'
+    alias egrep='egrep --color=auto'
+fi
+
+# some more ls aliases
+alias ll='ls -alF'
+alias la='ls -A'
+alias l='ls -CF'
+
+# Alias definitions.
+# You may want to put all your additions into a separate file like
+# ~/.bash_aliases, instead of adding them here directly.
+# See /usr/share/doc/bash-doc/examples in the bash-doc package.
+
+if [ -f ~/.bash_aliases ]; then
+    . ~/.bash_aliases
+fi
+
+# enable programmable completion features (you don't need to enable
+# this, if it's already enabled in /etc/bash.bashrc and /etc/profile
+# sources /etc/bash.bashrc).
+if [ -f /etc/bash_completion ] && ! shopt -oq posix; then
+    . /etc/bash_completion
+fi
+
+export WORKON_HOME=$HOME/.virtualenvs
+export PIP_DOWNLOAD_CACHE=$HOME/.pip_download_cache
+source /usr/local/bin/virtualenvwrapper.sh

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Script to set up a Django project on Vagrant.
+
+# Installation settings
+
+PROJECT_NAME=$1
+
+DB_NAME=$PROJECT_NAME
+VIRTUALENV_NAME=$PROJECT_NAME
+
+PROJECT_DIR=/home/vagrant/$PROJECT_NAME
+VIRTUALENV_DIR=/home/vagrant/.virtualenvs/$PROJECT_NAME
+
+# Python development packages
+PACKAGES="build-essential python python-dev python-distribute python-pip"
+
+export LANGUAGE=en_US.UTF-8
+export LANG=en_US.UTF-8
+export LC_ALL=en_US.UTF-8
+
+# Update the apt cache
+apt-get update -y
+
+apt-get install -y $PACKAGES
+
+# virtualenv global setup
+pip install virtualenv virtualenvwrapper stevedore virtualenv-clone
+
+# bash environment global setup
+cp -p $PROJECT_DIR/vagrant/bashrc /home/vagrant/.bashrc
+su - vagrant -c "mkdir -p /home/vagrant/.pip_download_cache"
+
+# ---
+
+# virtualenv setup for project
+su - vagrant -c "/usr/local/bin/virtualenv $VIRTUALENV_DIR && \
+    echo $PROJECT_DIR > $VIRTUALENV_DIR/.project && \
+    PIP_DOWNLOAD_CACHE=/home/vagrant/.pip_download_cache $VIRTUALENV_DIR/bin/pip install -r $PROJECT_DIR/requirements.txt"
+
+# run setup.py develop
+su - vagrant -c "cd $PROJECT_DIR && $VIRTUALENV_DIR/bin/python setup.py develop"
+
+# add in ipython
+su - vagrant -c "$VIRTUALENV_DIR/bin/pip install ipython"
+
+# activate the virtualenv as soon as we shell in
+echo "workon $VIRTUALENV_NAME" >> /home/vagrant/.bashrc


### PR DESCRIPTION
I added a basic Vagrantfile with provisioning script that I copied from another project of mine. It works out of the box and sets everything up properly.

Before I continued (by updating the docs to mention the Vagrantfile file, for instance) I just wanted to get a blessing (or curse) from upstream.

This provisioning script will install required packages, create a virtualenv, install the python requirements as well as setup `.bashrc` to automatically activate the environment and cd into the project when you ssh in.
