### PR TITLE
fixing the fixed height of .change_form

### DIFF
--- a/djadmin2/static/themes/bootstrap/css/bootstrap-custom.css
+++ b/djadmin2/static/themes/bootstrap/css/bootstrap-custom.css
@@ -34,7 +34,9 @@
 .change_form {
 	border: 1px solid #C6BCBC;
 	border-radius: 5px;
-	height: 360px;
+}
+.change_form .controls{
+    display: inline-block;
 }
 
 label {


### PR DESCRIPTION
Fixing the fixed height of the `.change_form` in order to provide an "auto height".

I think that it was fixed in 360px because when `.controls` has only the _label_ (when the field is a checkbox, for example), this _label_ overflows the div .controls.
