### PR TITLE
Removed some duplication of savebutton markup in templates

### DIFF
--- a/djadmin2/templates/djadmin2/bootstrap/includes/save_buttons.html
+++ b/djadmin2/templates/djadmin2/bootstrap/includes/save_buttons.html
@@ -1,6 +1,16 @@
-{% load i18n %}
-<div class="pull-right">
-  <button class="btn btn-small" type="submit" name="_addanother">{% trans "Save and add another" %}</button>
-  <button class="btn btn-small" type="submit" name="_continue">{% trans "Save and continue editing" %}</button>
-  <button class="btn btn-small btn-success" type="submit" name="_save">{% trans "Save" %}</button>
+{% load admin2_tags i18n %}
+<div class="row-fluid">
+  <div class="span12 save_btns">
+      {% if object %}
+      <a class="btn btn-small btn-danger" href="{% url view|admin2_urlname:'delete' pk=object.pk %}">
+        <i class="icon-remove icon-white"></i>
+        {% trans "Delete" %}
+      </a>
+      {% endif %}
+      <div class="pull-right">
+        <button class="btn btn-small" type="submit" name="_addanother">{% trans "Save and add another" %}</button>
+        <button class="btn btn-small" type="submit" name="_continue">{% trans "Save and continue editing" %}</button>
+        <button class="btn btn-small btn-success" type="submit" name="_save">{% trans "Save" %}</button>
+      </div>
+    </div>
 </div>

--- a/djadmin2/templates/djadmin2/bootstrap/model_update_form.html
+++ b/djadmin2/templates/djadmin2/bootstrap/model_update_form.html
@@ -43,17 +43,7 @@
     <form method="post">
        
       {% if view.model_admin.save_on_top %}
-      <div class="row-fluid">
-        <div class="span12 save_btns">
-            {% if object %}
-            <a class="btn btn-small btn-danger" href="{% url view|admin2_urlname:'delete' pk=object.pk %}">
-              <i class="icon-remove icon-white"></i>
-              {% trans "Delete" %}
-            </a>
-            {% endif %}
-              {% include "djadmin2/bootstrap/includes/save_buttons.html" %}
-          </div>
-      </div>
+        {% include "djadmin2/bootstrap/includes/save_buttons.html" %}
       {% endif %}
 
 <div class="row-fluid"><!-- begin main form row -->
@@ -110,17 +100,7 @@
 </div><!-- end main form row -->
       
       {% if view.model_admin.save_on_bottom %}
-      <div class="row-fluid">
-        <div class="span12 save_btns">
-            {% if object %}
-            <a class="btn btn-small btn-danger" href="{% url view|admin2_urlname:'delete' pk=object.pk %}">
-              <i class="icon-remove icon-white"></i>
-              {% trans "Delete" %}
-            </a>
-            {% endif %}
-              {% include "djadmin2/bootstrap/includes/save_buttons.html" %}
-          </div>
-      </div>
+        {% include "djadmin2/bootstrap/includes/save_buttons.html" %}
       {% endif %}
       
 </form>


### PR DESCRIPTION
I noticed that the markup for the savebuttons was duplicated. The duplicated code had a include, save_buttons.html which is not used anywhere else. I think it would make sense to move this entire block into that include.
