### PR TITLE
Inlines separated into stacked and tabular, fixes #334

### DIFF
--- a/djadmin2/__init__.py
+++ b/djadmin2/__init__.py
@@ -16,9 +16,11 @@ from . import types
 
 default = core.Admin2()
 ModelAdmin2 = types.ModelAdmin2
-Admin2Inline = types.Admin2Inline
+Admin2TabularInline = types.Admin2TabularInline
+Admin2StackedInline = types.Admin2StackedInline
 
 # Utility to make migration between versions easier
 sites = default
 ModelAdmin = ModelAdmin2
-AdminInline = Admin2Inline
+AdminInline = Admin2TabularInline
+Admin2Inline = Admin2TabularInline

--- a/djadmin2/templates/djadmin2/bootstrap/edit_inlines/stacked.html
+++ b/djadmin2/templates/djadmin2/bootstrap/edit_inlines/stacked.html
@@ -1,0 +1,7 @@
+{% load admin2_tags crispy_forms_tags %}
+
+{% for inline_form in formset %}
+  <div class="change_form space-below">
+  {{ inline_form|crispy }}
+  </div>
+{% endfor %}

--- a/djadmin2/templates/djadmin2/bootstrap/edit_inlines/tabular.html
+++ b/djadmin2/templates/djadmin2/bootstrap/edit_inlines/tabular.html
@@ -1,0 +1,37 @@
+{% load admin2_tags %}
+
+<table class="table table-striped table-bordered">
+  <thead>
+    <tr>
+    {% for field in formset|formset_visible_fieldlist %}
+    <th>{{ field }}</th>
+    {% endfor %}
+    </tr>
+  </thead>
+  <tbody>
+    {% for inline_form in formset %}
+    <tr>
+      {% for field in inline_form.visible_fields %}
+      <td>
+        {% if forloop.first %}
+        {% for hidden_field in inline_form.hidden_fields %}
+        {{ hidden_field }}
+        {% endfor %}
+        {% endif %}
+        {{ field }}
+      </td>
+      {% endfor %}
+    </tr>
+    {% endfor %}
+    <tr class="new_row">
+      <td colspan="3">
+        <div class="add_comment">
+          <a href="#" class="btn btn-small">
+            <i class="icon-plus"></i>
+            Add another comment
+          </a>
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/djadmin2/templates/djadmin2/bootstrap/model_update_form.html
+++ b/djadmin2/templates/djadmin2/bootstrap/model_update_form.html
@@ -58,42 +58,7 @@
       <div class="comments_form">
       <h4>{{ formset.model|model_verbose_name_plural|capfirst }}</h4>
       {{ formset.management_form }}
-      <table class="table table-striped table-bordered">
-        <thead>
-          <tr>
-          {% for field in formset|formset_visible_fieldlist %}
-          <th>{{ field }}</th>
-          {% endfor %}
-          </tr>
-        </thead>
-        <tbody>
-          {% for inline_form in formset %}
-          <tr>
-            {% for field in inline_form.visible_fields %}
-            <td>
-              {% if forloop.first %}
-              {% for hidden_field in inline_form.hidden_fields %}
-              {{ hidden_field }}
-              {% endfor %}
-              {% endif %}
-              {{ field }}
-            </td>
-            {% endfor %}
-          </tr>
-          {% endfor %}
-          <tr class="new_row">
-            <td colspan="3">
-              <div class="add_comment">
-                <a href="#" class="btn btn-small">
-                  <i class="icon-plus"></i>
-                  Add another comment
-                </a>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-              
-      </table>
+      {% include formset.template %}
       {% endfor %}
 
   </div>

--- a/djadmin2/types.py
+++ b/djadmin2/types.py
@@ -3,6 +3,7 @@ from __future__ import division, absolute_import, unicode_literals
 
 from collections import namedtuple
 import logging
+import os
 
 from django.core.urlresolvers import reverse
 from django.conf.urls import patterns, url
@@ -255,6 +256,7 @@ class Admin2Inline(extra_views.InlineFormSet):
     A simple extension of django-extra-view's InlineFormSet that
     adds some useful functionality.
     """
+    template = None
 
     def construct_formset(self):
         """
@@ -263,7 +265,16 @@ class Admin2Inline(extra_views.InlineFormSet):
         """
         formset = super(Admin2Inline, self).construct_formset()
         formset.model = self.inline_model
+        formset.template = self.template
         return formset
+
+
+class Admin2TabularInline(Admin2Inline):
+    template = os.path.join(settings.ADMIN2_THEME_DIRECTORY, 'edit_inlines/tabular.html')
+
+
+class Admin2StackedInline(Admin2Inline):
+    template = os.path.join(settings.ADMIN2_THEME_DIRECTORY, 'edit_inlines/stacked.html')
 
 
 def immutable_admin_factory(model_admin):

--- a/example/blog/admin2.py
+++ b/example/blog/admin2.py
@@ -13,7 +13,7 @@ from .actions import CustomPublishAction
 from .models import Post, Comment
 
 
-class CommentInline(djadmin2.Admin2Inline):
+class CommentInline(djadmin2.Admin2TabularInline):
     model = Comment
 
 

--- a/example2/polls/admin2.py
+++ b/example2/polls/admin2.py
@@ -6,7 +6,7 @@ import djadmin2
 from .models import Poll, Choice
 
 
-class ChoiceInline(djadmin2.Admin2Inline):
+class ChoiceInline(djadmin2.Admin2TabularInline):
     model = Choice
     extra = 3
 


### PR DESCRIPTION
Uses similair approach as the old admin. Different template is set on the inline class for tabular and stacked.

Admin2Inline can no longer be used as inline directly, therefore I also changed the import in **init** to use tabular as a fallback to ease migration to this version.

Examples are updated to use tabular instead. Maybe one of them should use stacked, just for the sake of using it?

Not sure how to add tests for this. Admin2Inline is kind of icky to initialize. Suggestions are welcome.
