### PR TITLE
fix TypeError - the right way

### DIFF
--- a/djadmin2/apiviews.py
+++ b/djadmin2/apiviews.py
@@ -75,7 +75,7 @@ class IndexAPIView(Admin2APIMixin, APIView):
         return {
             'app_label': app_label,
             'models': model_data,
-            'app_verbose_name': unicode(self.app_verbose_names.get(app_label))
+            'app_verbose_name': force_str(self.app_verbose_names.get(app_label))
         }
 
     def get(self, request):


### PR DESCRIPTION
Using `django.utils.encoding.force_str` instead `unicode` in order to avoid the (example):

```
TypeError at /admin2/api/v0/

<django.utils.functional.__proxy__ object at 0x2f30b50> is not JSON serializable
```
