### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -12,5 +12,5 @@ Also, please read the following:
 * Our design_ document, which lists the constraints and goals of the project.
 * Our contributing_ document, which describes our procedures and methods.
 
-.. _design: https://django-admin2.readthedocs.org/en/latest/design.html
-.. _contributing: https://django-admin2.readthedocs.org/en/latest/contributing.html
+.. _design: https://django-admin2.readthedocs.io/en/latest/design.html
+.. _contributing: https://django-admin2.readthedocs.io/en/latest/contributing.html

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -57,9 +57,9 @@ History
  * Pull requests going forward are internationalized_
  * FAQ_ begun
  
-.. _`internationalized`: https://django-admin2.readthedocs.org/en/latest/contributing.html#internationalize
-.. _`Documentation on built-in views`: https://django-admin2.readthedocs.org/en/latest/ref/built-in-views.html
-.. _faq: https://django-admin2.readthedocs.org/en/latest/faq.html
+.. _`internationalized`: https://django-admin2.readthedocs.io/en/latest/contributing.html#internationalize
+.. _`Documentation on built-in views`: https://django-admin2.readthedocs.io/en/latest/ref/built-in-views.html
+.. _faq: https://django-admin2.readthedocs.io/en/latest/faq.html
 
 0.5.0 (2013-07-08)
 

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ rewrite of that library using modern Class-Based Views and enjoying a design
 focused on extendibility and adaptability. By starting over, we can avoid the
 legacy code and make it easier to write extensions and themes.
 
-Full Documentation at: http://django-admin2.rtfd.org/
+Full Documentation at: https://django-admin2.readthedocs.io/
 
 Features
 ========

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -266,7 +266,7 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('http://python.readthedocs.org/en/v2.7.2/', None),
+    'python': ('https://python.readthedocs.io/en/v2.7.2/', None),
     'django': (
         'http://docs.djangoproject.com/en/dev/',
         'http://docs.djangoproject.com/en/dev/_objects/'

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -6,7 +6,7 @@ Contributing
 
 .. warning:: Before you begin working on your contribution, please read and become familiar with the design_ of ``django-admin2``. The design_ document should hopefully make it clear what our constraints and goals are for the project.
 
-.. _design: https://django-admin2.readthedocs.org/en/latest/design.html
+.. _design: https://django-admin2.readthedocs.io/en/latest/design.html
 
 .. index::
     single: Contributing; Setup
@@ -42,7 +42,7 @@ Try the example projects
 3. run the dev server: ``$ python manage.py runserver``
 
 .. _virtualenv: http://www.virtualenv.org/en/latest/
-.. _virtualenvwrapper: http://virtualenvwrapper.readthedocs.org/en/latest/
+.. _virtualenvwrapper: https://virtualenvwrapper.readthedocs.io/en/latest/
 
 .. index::
     single: Contributing; Issues
@@ -254,7 +254,7 @@ Internationalize
 
 Any new text visible to the user must be internationalized_.
 
-.. _internationalized: https://django-admin2.readthedocs.org/en/latest/internationalization.html
+.. _internationalized: https://django-admin2.readthedocs.io/en/latest/internationalization.html
 
 
 How pull requests are checked, tested, and done


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.