### PR TITLE
Fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
   - python: '3.3'
     env: DJANGO=1.9
   - python: '3.3'
+    env: DJANGO=1.10
+  - python: '3.3'
     env: DJANGO=master
   allow_failures:
   - python: '2.7'

--- a/djadmin2/templatetags/admin2_tags.py
+++ b/djadmin2/templatetags/admin2_tags.py
@@ -138,7 +138,7 @@ def render(context, model_instance, attribute_name):
 
     # Apply renderer and return value
     try:
-        field = model_instance._meta.get_field_by_name(attribute_name)[0]
+        field = model_instance._meta.get_field(attribute_name)
     except FieldDoesNotExist:
         # There is no field with the specified name.
         # It must be a method instead.

--- a/djadmin2/tests/test_renderers.py
+++ b/djadmin2/tests/test_renderers.py
@@ -117,6 +117,6 @@ class NumberRendererTest(TestCase):
         self.assertEqual(number, out)
 
     def testFieldDecimal(self):
-        field = RendererTestModel._meta.get_field_by_name('decimal')[0]
+        field = RendererTestModel._meta.get_field('decimal')
         out = self.renderer(Decimal('0.123456789'), field)
         self.assertEqual('0.12345', out)

--- a/djadmin2/utils.py
+++ b/djadmin2/utils.py
@@ -73,7 +73,7 @@ def model_field_verbose_name(model, field_name):
     Returns the verbose name of a model field.
     """
     meta = model_options(model)
-    field = meta.get_field_by_name(field_name)[0]
+    field = meta.get_field(field_name)
     return field.verbose_name
 
 

--- a/docs/ref/meta.rst
+++ b/docs/ref/meta.rst
@@ -149,7 +149,7 @@ Attributes
     ``admin``
         Is ``None``. Doesn't seem to be used anywhere. So we don't need to
         document it.
-        
+
         TODO: Create a django ticket to suggest removing it.
 
 ``auto_created``
@@ -249,9 +249,6 @@ Methods
     TODO ...
 
 ``get_field(self, name, many_to_many=True)``
-    TODO ...
-
-``get_field_by_name(self, name)``
     TODO ...
 
 ``get_all_field_names(self)``

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-django-extra-views>=0.8.0
+django-extra-views<=0.7.1
 django-braces>=1.3.0
-djangorestframework>=3.5.3
+djangorestframework<=3.3.3
 django-filter>=0.15.3
 django-debug-toolbar>=1.5
 future>=0.15.2

--- a/setup.py
+++ b/setup.py
@@ -128,10 +128,10 @@ setup(
     #test_suite='runtests.runtests',
     install_requires=[
         'django>=1.8.0',
-        'django-extra-views>=0.6.5',
+        'django-extra-views<=0.7.1',
         'django-braces>=1.3.0',
-        'djangorestframework>=3.3.3',
-        'django-filter>=0.13.0',
+        'djangorestframework<=3.3.3',
+        'django-filter>=0.15.3',
         'pytz==2016.4',
         'future>=0.15.2',
         ],

--- a/tox.ini
+++ b/tox.ini
@@ -24,4 +24,3 @@ deps =
 setenv=
     DJANGO_SETTINGS_MODULE = example.settings
     PYTHONPATH = {toxinidir}/example:{toxinidir}
-

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,6 @@ deps =
     1.9: Django>=1.9,<1.10
     1.10: Django>=1.10,<1.11
     master: https://github.com/django/django/tarball/master
-usedevelop = True
 setenv=
     DJANGO_SETTINGS_MODULE = example.settings
     PYTHONPATH = {toxinidir}/example:{toxinidir}


### PR DESCRIPTION
* remove tox development mode
* fix django extra-views and django-rest-framework versions
* use `_meta.get_field` instead `_meta.get_field_by_name` to fix the compatibility with Django 1.10

/cc @galuszkak and @auvipy 