### PR TITLE
docs: Fix simple typo, taht -> that

### DIFF
--- a/djadmin2/filters.py
+++ b/djadmin2/filters.py
@@ -24,7 +24,7 @@ class NumericDateFilter(django_filters.DateFilter):
 
 
 class ChoicesAsLinksWidget(django_widgets.Select):
-    """Select form widget taht renders links for choices
+    """Select form widget that renders links for choices
     instead of select element with options.
     """
 


### PR DESCRIPTION
There is a small typo in djadmin2/filters.py.

Should read `that` rather than `taht`.

